### PR TITLE
Use environment variable to determine hostname

### DIFF
--- a/idoit-install
+++ b/idoit-install
@@ -1108,7 +1108,7 @@ function configureApache {
 
     log "Configure Apache Web server"
 
-    hostname="$(cat /etc/hostname)"
+    hostname="$HOSTNAME"
 
     case "$OS" in
         "rhel7"|"rhel8"|"centos7"|"centos8")


### PR DESCRIPTION
Since the hostname might not be noted inside the currently used /etc/hostname file (for whatever reason), the designated environment variable should be used for determining the system's hostname instead. Otherwise, the apache config will contain a wrong or even empty ServerName, causing the setup to fail.