### PR TITLE
Modified installation procedures for RHEL 8 and CentOS 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.deb
 package-lock.json
 /node_modules/
+/.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `idoit-install`: Add support for CentOS 8
 -   `idoit-install`: Add support for Ubuntu Linux 20.04 LTS "focal fossa"
+-   `idoit-install`: Add support for openSUSE "leap" 15, 15.1 and 15.2
+-   `idoit-install`: Add new logic to configure MariaDB based on the operating system and MariaDB version used
+-   `idoit-install`: Add support for MariaDB 10.4
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ The script [`idoit-install`](idoit-install) allows you to easily install the **l
 
 on a **fresh installation of a GNU/Linux operating system**. Supported OSs are:
 
-- Debian GNU/Linux 10 "buster" (**recommended**)
-- Ubuntu Linux 18.04 LTS "bionic" and 20.04 LTS "focal fossa"
-- Red Hat Enterprise Linux (RHEL) 7 (deprecated) and (RHEL) 8
-- CentOS 7 (deprecated) and CentOS 8
-- SUSE Linux Enterprise Server 15, 15 SP1 and 15 SP2
-- openSUSE "leap" 15, 15.1 and 15.2
+-   Debian GNU/Linux 10 "buster" (**recommended**)
+-   Ubuntu Linux 18.04 LTS "bionic" and 20.04 LTS "focal fossa"
+-   Red Hat Enterprise Linux (RHEL) 7 (deprecated) and (RHEL) 8
+-   CentOS 7 (deprecated) and CentOS 8
+-   SUSE Linux Enterprise Server 15, 15 SP1 and 15 SP2
+-   openSUSE "leap" 15, 15.1 and 15.2
 
 Before you execute this script you …
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ The script [`idoit-install`](idoit-install) allows you to easily install the **l
 
 on a **fresh installation of a GNU/Linux operating system**. Supported OSs are:
 
--   Debian GNU/Linux 10 "buster" (**recommended**)
--   Ubuntu Linux 18.04 LTS "bionic"
--   Red Hat Enterprise Linux (RHEL) 7 (deprecated) and 8
--   CentOS 7 (deprecated)
--   SUSE Linux Enterprise Server 15 and 15 SP1
+- Debian GNU/Linux 10 "buster" (**recommended**)
+- Ubuntu Linux 18.04 LTS "bionic" and 20.04 LTS "focal fossa"
+- Red Hat Enterprise Linux (RHEL) 7 (deprecated) and (RHEL) 8
+- CentOS 7 (deprecated) and CentOS 8
+- SUSE Linux Enterprise Server 15, 15 SP1 and 15 SP2
+- openSUSE "leap" 15, 15.1 and 15.2
 
 Before you execute this script you …
 

--- a/idoit-install
+++ b/idoit-install
@@ -694,7 +694,6 @@ function configureCentOS8 {
         php-pgsql php-soap php-zip || \
         abort "Unable to install packages"
 
-
     if ! rpm -qa | grep "epel-release" > /dev/null; then
         log "Import EPEL public GPG key"
         rpm --import --quiet https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8 || \
@@ -704,7 +703,7 @@ function configureCentOS8 {
             abort "Unable to install epel releases repository"
     fi
 
-    log "Enable PowerTools for CentOS"
+    log "Enable PowerTools for CentOS 8"
     dnf --assumeyes --quiet config-manager --set-enabled powertools || \
         abort "Unable to enable PowerTools"
 
@@ -745,22 +744,22 @@ function configureRHEL8 {
         php-pgsql php-soap php-zip || \
         abort "Unable to install packages"
 
-    if [[ ! -x "$(command -v chronic)" ]]; then
-        log "Install 'chronic'"
-        ## TODO: I know, this seems to be pretty ugly, but:
-        ## Why the hack is moreutils not included in the standard repositories?!?
-        wget --quiet -O "${TMP_DIR}/chronic" \
-            https://git.joeyh.name/index.cgi/moreutils.git/plain/chronic || \
-            abort "Unable to download 'chronic'"
-        chmod +x "${TMP_DIR}/chronic" || \
-            abort "Unable to set executable bit"
-        mv "${TMP_DIR}/chronic" /usr/local/bin || \
-            abort "Unable to move 'chronic' to '/usr/local/bin'"
-        yum --assumeyes --quiet module install perl-App-cpanminus || \
-            abort "Unable to install cpanm"
-        cpanm --quiet --notest --install IPC::Run || \
-            abort "Unable to install Perl module IPC::Run"
+    if ! rpm -qa | grep "epel-release" > /dev/null; then
+        log "Import EPEL public GPG key"
+        rpm --import --quiet https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8 || \
+            abort "Unable to import public GPG key from EPEL"
+        log "Add epel releases repository"
+        rpm -Uvh --quiet https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || \
+            abort "Unable to install epel releases repository"
     fi
+
+    log "Enable codeready-builder for RHEL 8"
+    subscription-manager repos --enable "codeready-builder-for-rhel-8-x86_64-rpms" || \
+        abort "Unable to enable Codeready-Builder"
+
+    log "Install moreutils with all dependencies"
+    dnf --assumeyes --quiet install moreutils || \
+        abort "Unable to install moreutils"
 
     for unit in $APACHE_UNIT $MARIADB_UNIT $MEMCACHED_UNIT $PHP_FPM_UNIT; do
         unitctl "enable" "$unit"

--- a/idoit-install
+++ b/idoit-install
@@ -347,11 +347,29 @@ function identifyOS {
         MARIADB_SOCKET="/var/run/mysql/mysql.sock"
         PHP_FPM_SOCKET="/var/run/php-fpm.sock"
         APACHE_UNIT="apache2"
-        MARIADB_UNIT="mysql"
+        MARIADB_UNIT="mariadb"
         MEMCACHED_UNIT="memcached"
         PHP_FPM_UNIT="php-fpm"
     elif [[ "$NAME" = "SLES" && "$VERSION_ID" == 12* ]]; then
         abort "Error: SLES 12 is out-dated. It's not supported anymore. Please upgrade."
+
+    elif [[ "$NAME" == "openSUSE Leap" && "$VERSION" == 15* ]]; then
+        OS="opensuse15"
+        INSTALL_DIR="/srv/www/htdocs"
+        APACHE_USER="wwwrun"
+        APACHE_GROUP="www"
+        APACHE_CONFIG_FILE="/etc/apache2/vhosts.d/i-doit.conf"
+        MARIADB_CONFIG_FILE="/etc/my.cnf.d/99-i-doit.cnf"
+        PHP_CONFIG_FILE="/etc/php7/conf.d/i-doit.ini"
+        MARIADB_SOCKET="/var/run/mysql/mysql.sock"
+        PHP_FPM_SOCKET="/var/run/php-fpm.sock"
+        APACHE_UNIT="apache2"
+        MARIADB_UNIT="mariadb"
+        MEMCACHED_UNIT="memcached"
+        PHP_FPM_UNIT="php-fpm"
+    elif [[ "$NAME" = "openSUSE" && "$VERSION_ID" == 12* ]]; then
+        abort "Error: openSUSE 12 is out-dated. It's not supported anymore. Please upgrade."
+
     elif [[ "$NAME" == "Ubuntu" && "$VERSION_ID" == "20.04" ]]; then
         export DEBIAN_FRONTEND="noninteractive"
         OS="ubuntu2004"
@@ -533,6 +551,9 @@ function configureOS {
             ;;
         "sles15")
             configureSLES15
+            ;;
+        "opensuse15")
+            configureOpenSuse15
             ;;
         *)
             abort "Unkown operating system '${OS}'!?!"
@@ -914,16 +935,86 @@ function configureSLES15 {
         log ""
         log "    https://software.opensuse.org/download.html?project=server%3Aphp%3Aextensions%3Aphp7&package=php7-memcached"
 
-        zypper --quiet --non-interactive addrepo \
-            --gpgcheck --refresh \
-            https://download.opensuse.org/repositories/server:php:extensions:php7/SLE_15/server:php:extensions:php7.repo || \
-            abort "Unable to add repository"
-        zypper --quiet --non-interactive --gpg-auto-import-keys refresh || \
-            abort "Unable to refresh software repositories"
+        if [[ "$VERSION_ID" == 15 ]]; then
+            zypper --quiet --non-interactive addrepo \
+                --gpgcheck --refresh \
+                https://download.opensuse.org/repositories/server:php:extensions:php7/SLE_15/server:php:extensions:php7.repo || \
+                abort "Unable to add repository"
+            zypper --quiet --non-interactive --gpg-auto-import-keys refresh || \
+                abort "Unable to refresh software repositories"
+
+        elif [[ "$VERSION_ID" == 15.1 ]]; then
+            zypper --quiet --non-interactive addrepo \
+                --gpgcheck --refresh \
+                https://download.opensuse.org/repositories/server:/php:/extensions/SLE_15_SP1/server:php:extensions.repo || \
+                abort "Unable to add repository"
+            zypper --quiet --non-interactive --gpg-auto-import-keys refresh || \
+                abort "Unable to refresh software repositories"
+
+        elif [[ "$VERSION_ID" == 15.2 ]]; then
+            zypper --quiet --non-interactive addrepo \
+                --gpgcheck --refresh \
+                https://download.opensuse.org/repositories/server:/php:/extensions/SLE_15_SP2/server:php:extensions.repo || \
+                abort "Unable to add repository"
+            zypper --quiet --non-interactive --gpg-auto-import-keys refresh || \
+                abort "Unable to refresh software repositories"
+        fi
     fi
 
     zypper --quiet --non-interactive install --no-recommends php7-memcached || \
         abort "Unable to install required software package"
+
+    zypper --quiet --non-interactive clean || abort "Unable to clean up cached software packages"
+
+    for unit in $APACHE_UNIT $MARIADB_UNIT $MEMCACHED_UNIT; do
+        unitctl "enable" "$unit"
+        unitctl "start" "$unit"
+    done
+
+    log "Allow incoming HTTP traffic"
+    systemctl -q is-active firewalld.service || (
+        log "Firewall is inactive."
+        unitctl "start" "firewalld"
+    )
+    firewall-cmd --permanent --add-service=http || abort "Unable to configure firewall"
+    unitctl "restart" "firewalld"
+
+    if [[ ! -x "$(command -v chronic)" ]]; then
+        log "Install 'chronic'"
+        ## TODO: I know, this seems to be pretty ugly, but:
+        ## Why the hack is moreutils not included in the standard repositories?!?
+        wget --quiet -O "${TMP_DIR}/chronic" \
+            https://git.joeyh.name/index.cgi/moreutils.git/plain/chronic || \
+            abort "Unable to download 'chronic'"
+        chmod +x "${TMP_DIR}/chronic" || \
+            abort "Unable to set executable bit"
+        mv "${TMP_DIR}/chronic" /usr/bin || \
+            abort "Unable to move 'chronic' to '/usr/bin'"
+        wget --quiet -O - https://cpanmin.us | perl - App::cpanminus || \
+            abort "Unable to install cpanminus"
+        cpanm --quiet --notest --install IPC::Run || \
+            abort "Unable to install Perl module IPC::Run"
+    fi
+}
+
+function configureOpenSuse15 {
+    local web_repos=""
+    local openSuseRepo=""
+
+    log "Keep your packages up-to-date"
+    zypper --quiet --non-interactive refresh || abort "Unable to refresh software repositories"
+    zypper --quiet --non-interactive update || abort "Unable to update software packages"
+
+    log "Install software packages"
+    zypper --quiet --non-interactive install --no-recommends \
+        apache2 \
+        mariadb mariadb-client \
+        memcached \
+        make sudo unzip \
+        php7 php7-bcmath php7-bz2 php7-ctype php7-curl php7-fpm php7-gd php7-gettext php7-fileinfo \
+        php7-json php7-ldap php7-mbstring php7-mysql php7-memcached php7-opcache php7-openssl php7-pdo \
+        php7-pgsql php7-phar php7-posix php7-soap php7-sockets php7-sqlite php7-xsl php7-zip php7-zlib || \
+        abort "Unable to install required software packages"
 
     zypper --quiet --non-interactive clean || abort "Unable to clean up cached software packages"
 
@@ -1070,7 +1161,7 @@ security.limit_extensions = .php
 EOF
             unitctl "restart" "$PHP_FPM_UNIT"
             ;;
-        "sles15")
+        "sles15" | "opensuse15" )
             log "Enable PHP FPM configuration files"
             mv /etc/php7/fpm/php-fpm.conf{.default,} || \
                 abort "Unable to move file"
@@ -1169,7 +1260,7 @@ EOF
 
             unitctl "restart" "$APACHE_UNIT"
             ;;
-        "sles15")
+        "sles15" | "opensuse15")
             a2_en_mod=$(command -v a2enmod)
 
             cat << EOF > ${APACHE_CONFIG_FILE} || \
@@ -1427,13 +1518,16 @@ function secureMariaDB {
     "$MARIADB_BIN" \
         -h"$MARIADB_HOSTNAME" \
         -u"$MARIADB_SUPERUSER_USERNAME" \
-        -e"UPDATE mysql.user SET Password=PASSWORD('${MARIADB_SUPERUSER_PASSWORD}'), plugin='mysql_native_password' WHERE User='${MARIADB_SUPERUSER_USERNAME}';" || \
+        -p"$MARIADB_SUPERUSER_PASSWORD" \
+        -e"ALTER USER '${MARIADB_SUPERUSER_USERNAME}'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('${MARIADB_SUPERUSER_PASSWORD}');" || \
+##        -e"UPDATE mysql.user SET Password=PASSWORD('${MARIADB_SUPERUSER_PASSWORD}'), plugin='mysql_native_password' WHERE User='${MARIADB_SUPERUSER_USERNAME}';" || \
         abort "SQL statement failed"
 
     log "Allow $MARIADB_SUPERUSER_USERNAME login only from localhost"
     "$MARIADB_BIN" \
         -h"$MARIADB_HOSTNAME" \
         -u"$MARIADB_SUPERUSER_USERNAME" \
+        -p"$MARIADB_SUPERUSER_PASSWORD" \
         -e"DELETE FROM mysql.user WHERE User='${MARIADB_SUPERUSER_USERNAME}' AND Host NOT IN ('localhost', '127.0.0.1', '::1');" || \
         abort "SQL statement failed"
 
@@ -1441,6 +1535,7 @@ function secureMariaDB {
     "$MARIADB_BIN" \
         -h"$MARIADB_HOSTNAME" \
         -u"$MARIADB_SUPERUSER_USERNAME" \
+        -p"$MARIADB_SUPERUSER_PASSWORD" \
         -e"DELETE FROM mysql.user WHERE User='';" || \
         abort "SQL statement failed"
 
@@ -1448,6 +1543,7 @@ function secureMariaDB {
     "$MARIADB_BIN" \
         -h"$MARIADB_HOSTNAME" \
         -u"$MARIADB_SUPERUSER_USERNAME" \
+        -p"$MARIADB_SUPERUSER_PASSWORD" \
         -e"DELETE FROM mysql.db WHERE Db='test' OR Db='test_%';" || \
         abort "SQL statement failed"
 
@@ -1455,6 +1551,7 @@ function secureMariaDB {
     "$MARIADB_BIN" \
         -h"$MARIADB_HOSTNAME" \
         -u"$MARIADB_SUPERUSER_USERNAME" \
+        -p"$MARIADB_SUPERUSER_PASSWORD" \
         -e"FLUSH PRIVILEGES;" || \
         abort "SQL statement failed"
 }

--- a/idoit-install
+++ b/idoit-install
@@ -694,22 +694,23 @@ function configureCentOS8 {
         php-pgsql php-soap php-zip || \
         abort "Unable to install packages"
 
-    if [[ ! -x "$(command -v chronic)" ]]; then
-        log "Install 'chronic'"
-        ## TODO: I know, this seems to be pretty ugly, but:
-        ## Why the hack is moreutils not included in the standard repositories?!?
-        wget --quiet -O "${TMP_DIR}/chronic" \
-            https://git.joeyh.name/index.cgi/moreutils.git/plain/chronic || \
-            abort "Unable to download 'chronic'"
-        chmod +x "${TMP_DIR}/chronic" || \
-            abort "Unable to set executable bit"
-        mv "${TMP_DIR}/chronic" /usr/local/bin || \
-            abort "Unable to move 'chronic' to '/usr/local/bin'"
-        yum --assumeyes --quiet module install perl-App-cpanminus || \
-            abort "Unable to install cpanm"
-        cpanm --quiet --notest --install IPC::Run || \
-            abort "Unable to install Perl module IPC::Run"
+
+    if ! rpm -qa | grep "epel-release" > /dev/null; then
+        log "Import EPEL public GPG key"
+        rpm --import --quiet https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8 || \
+            abort "Unable to import public GPG key from EPEL"
+        log "Add epel releases repository"
+        rpm -Uvh --quiet https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || \
+            abort "Unable to install epel releases repository"
     fi
+
+    log "Enable PowerTools for CentOS"
+    dnf --assumeyes --quiet config-manager --set-enabled powertools || \
+        abort "Unable to enable PowerTools"
+
+    log "Install moreutils with all dependencies"
+    dnf --assumeyes --quiet install moreutils || \
+        abort "Unable to install moreutils"
 
     for unit in $APACHE_UNIT $MARIADB_UNIT $MEMCACHED_UNIT $PHP_FPM_UNIT; do
         unitctl "enable" "$unit"

--- a/idoit-install
+++ b/idoit-install
@@ -51,7 +51,8 @@ IFS=$'\n\t'
 : "${JOBS_BIN:="/usr/local/bin/idoit-jobs"}"
 : "${CRON_FILE:="/etc/cron.d/i-doit"}"
 : "${BACKUP_DIR:="/var/backups/i-doit"}"
-: "${RECOMMENDED_PHP_VERSION:="7.3"}"
+: "${RECOMMENDED_PHP_VERSION:="7.4"}"
+: "${RECOMMENDED_MARIADB_VERSION:="10.4"}"
 
 ##
 ## Runtime settings
@@ -1505,6 +1506,10 @@ EOF
 }
 
 function secureMariaDB {
+    local mariadb_version=""
+
+    mariadb_version=$(mysql --version | head -n1 -c28 | tail -c 4)
+
     echo -n -e \
         "Please enter a new password for MariaDB's super user '${MARIADB_SUPERUSER_USERNAME}' [leave empty for '${MARIADB_SUPERUSER_PASSWORD}']: "
 
@@ -1515,45 +1520,94 @@ function secureMariaDB {
     fi
 
     log "Set $MARIADB_SUPERUSER_USERNAME password and plugin 'mysql_native_password'"
-    "$MARIADB_BIN" \
-        -h"$MARIADB_HOSTNAME" \
-        -u"$MARIADB_SUPERUSER_USERNAME" \
-        -p"$MARIADB_SUPERUSER_PASSWORD" \
-        -e"ALTER USER '${MARIADB_SUPERUSER_USERNAME}'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('${MARIADB_SUPERUSER_PASSWORD}');" || \
-##        -e"UPDATE mysql.user SET Password=PASSWORD('${MARIADB_SUPERUSER_PASSWORD}'), plugin='mysql_native_password' WHERE User='${MARIADB_SUPERUSER_USERNAME}';" || \
-        abort "SQL statement failed"
+    case "$mariadb_version" in
+        "10.4"|"10.5")
+            "$MARIADB_BIN" \
+            -h"$MARIADB_HOSTNAME" \
+            -u"$MARIADB_SUPERUSER_USERNAME" \
+            -e"SET PASSWORD FOR '${MARIADB_SUPERUSER_USERNAME}'@'localhost' = PASSWORD('${MARIADB_SUPERUSER_PASSWORD}');" \
+            -e"ALTER USER '${MARIADB_SUPERUSER_USERNAME}'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('${MARIADB_SUPERUSER_PASSWORD}');" || \
+            abort "SQL statement failed"
+            ;;
 
-    log "Allow $MARIADB_SUPERUSER_USERNAME login only from localhost"
-    "$MARIADB_BIN" \
-        -h"$MARIADB_HOSTNAME" \
-        -u"$MARIADB_SUPERUSER_USERNAME" \
-        -p"$MARIADB_SUPERUSER_PASSWORD" \
-        -e"DELETE FROM mysql.user WHERE User='${MARIADB_SUPERUSER_USERNAME}' AND Host NOT IN ('localhost', '127.0.0.1', '::1');" || \
-        abort "SQL statement failed"
+        "10.1"|"10.2"|"10.3")
+            "$MARIADB_BIN" \
+            -h"$MARIADB_HOSTNAME" \
+            -u"$MARIADB_SUPERUSER_USERNAME" \
+            -e"UPDATE mysql.user SET Password=PASSWORD('${MARIADB_SUPERUSER_PASSWORD}'), plugin='mysql_native_password' WHERE User='${MARIADB_SUPERUSER_USERNAME}';" || \
+            abort "SQL statement failed"
+            ;;
 
-    log "Remove anonymous user"
-    "$MARIADB_BIN" \
-        -h"$MARIADB_HOSTNAME" \
-        -u"$MARIADB_SUPERUSER_USERNAME" \
-        -p"$MARIADB_SUPERUSER_PASSWORD" \
-        -e"DELETE FROM mysql.user WHERE User='';" || \
-        abort "SQL statement failed"
+        *)
+            abort "MariaDB ${mariadb_version} is not supported. Please follow the system requirements. We recommend version ${RECOMMENDED_MARIADB_VERSION}."
+            ;;
+    esac
 
-    log "Remove test database"
-    "$MARIADB_BIN" \
-        -h"$MARIADB_HOSTNAME" \
-        -u"$MARIADB_SUPERUSER_USERNAME" \
-        -p"$MARIADB_SUPERUSER_PASSWORD" \
-        -e"DELETE FROM mysql.db WHERE Db='test' OR Db='test_%';" || \
-        abort "SQL statement failed"
+    case "$OS" in
+        "rhel7"|"rhel8"|"centos7"|"centos8")
+            log "Allow $MARIADB_SUPERUSER_USERNAME login only from localhost"
+            "$MARIADB_BIN" \
+                -h"$MARIADB_HOSTNAME" \
+                -u"$MARIADB_SUPERUSER_USERNAME" \
+                -e"DELETE FROM mysql.user WHERE User='${MARIADB_SUPERUSER_USERNAME}' AND Host NOT IN ('localhost', '127.0.0.1', '::1');" || \
+                abort "SQL statement failed"
 
-    log "Flush MariaDB user privileges"
-    "$MARIADB_BIN" \
-        -h"$MARIADB_HOSTNAME" \
-        -u"$MARIADB_SUPERUSER_USERNAME" \
-        -p"$MARIADB_SUPERUSER_PASSWORD" \
-        -e"FLUSH PRIVILEGES;" || \
-        abort "SQL statement failed"
+            log "Remove anonymous user"
+            "$MARIADB_BIN" \
+                -h"$MARIADB_HOSTNAME" \
+                -u"$MARIADB_SUPERUSER_USERNAME" \
+                -e"DELETE FROM mysql.user WHERE User='';" || \
+                abort "SQL statement failed"
+
+            log "Remove test database"
+            "$MARIADB_BIN" \
+                -h"$MARIADB_HOSTNAME" \
+                -u"$MARIADB_SUPERUSER_USERNAME" \
+                -e"DELETE FROM mysql.db WHERE Db='test' OR Db='test_%';" || \
+                abort "SQL statement failed"
+
+            log "Flush MariaDB user privileges"
+            "$MARIADB_BIN" \
+                -h"$MARIADB_HOSTNAME" \
+                -u"$MARIADB_SUPERUSER_USERNAME" \
+                -e"FLUSH PRIVILEGES;" || \
+                abort "SQL statement failed"
+            ;;
+
+        "sles15"|"opensuse15"|"debian10"|"ubuntu1804"|"ubuntu2004")
+            log "Allow $MARIADB_SUPERUSER_USERNAME login only from localhost"
+            "$MARIADB_BIN" \
+                -h"$MARIADB_HOSTNAME" \
+                -u"$MARIADB_SUPERUSER_USERNAME" \
+                -p"$MARIADB_SUPERUSER_PASSWORD" \
+                -e"DELETE FROM mysql.user WHERE User='${MARIADB_SUPERUSER_USERNAME}' AND Host NOT IN ('localhost', '127.0.0.1', '::1');" || \
+                abort "SQL statement failed"
+
+            log "Remove anonymous user"
+            "$MARIADB_BIN" \
+                -h"$MARIADB_HOSTNAME" \
+                -u"$MARIADB_SUPERUSER_USERNAME" \
+                -p"$MARIADB_SUPERUSER_PASSWORD" \
+                -e"DELETE FROM mysql.user WHERE User='';" || \
+                abort "SQL statement failed"
+
+            log "Remove test database"
+            "$MARIADB_BIN" \
+                -h"$MARIADB_HOSTNAME" \
+                -u"$MARIADB_SUPERUSER_USERNAME" \
+                -p"$MARIADB_SUPERUSER_PASSWORD" \
+                -e"DELETE FROM mysql.db WHERE Db='test' OR Db='test_%';" || \
+                abort "SQL statement failed"
+
+            log "Flush MariaDB user privileges"
+            "$MARIADB_BIN" \
+                -h"$MARIADB_HOSTNAME" \
+                -u"$MARIADB_SUPERUSER_USERNAME" \
+                -p"$MARIADB_SUPERUSER_PASSWORD" \
+                -e"FLUSH PRIVILEGES;" || \
+                abort "SQL statement failed"
+            ;;
+        esac
 }
 
 function prepareIDoit {
@@ -1959,3 +2013,5 @@ if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
 
     setup && execute && finish
 fi
+
+}

--- a/idoit-install
+++ b/idoit-install
@@ -682,7 +682,7 @@ function configureCentOS8 {
     yum --assumeyes --quiet clean all || abort "Unable to clean yum caches"
     rm -rf /var/cache/yum || abort "Unable to remove orphaned yum caches"
 
-    for appStream in httpd:2.4 mariadb:10.3 php:7.3; do
+    for appStream in httpd:2.4 mariadb:10.3 php:7.4; do
         log "Install AppStream $appStream"
         yum --assumeyes --quiet module install "$appStream"
     done
@@ -732,7 +732,7 @@ function configureRHEL8 {
     yum --assumeyes --quiet clean all || abort "Unable to clean yum caches"
     rm -rf /var/cache/yum || abort "Unable to remove orphaned yum caches"
 
-    for appStream in httpd:2.4 mariadb:10.3 php:7.3; do
+    for appStream in httpd:2.4 mariadb:10.3 php:7.4; do
         log "Install AppStream $appStream"
         yum --assumeyes --quiet module install "$appStream"
     done

--- a/idoit-install
+++ b/idoit-install
@@ -682,7 +682,7 @@ function configureCentOS8 {
     yum --assumeyes --quiet clean all || abort "Unable to clean yum caches"
     rm -rf /var/cache/yum || abort "Unable to remove orphaned yum caches"
 
-    for appStream in httpd:2.4 mariadb:10.3 php:7.2; do
+    for appStream in httpd:2.4 mariadb:10.3 php:7.3; do
         log "Install AppStream $appStream"
         yum --assumeyes --quiet module install "$appStream"
     done
@@ -732,7 +732,7 @@ function configureRHEL8 {
     yum --assumeyes --quiet clean all || abort "Unable to clean yum caches"
     rm -rf /var/cache/yum || abort "Unable to remove orphaned yum caches"
 
-    for appStream in httpd:2.4 mariadb:10.3 php:7.2; do
+    for appStream in httpd:2.4 mariadb:10.3 php:7.3; do
         log "Install AppStream $appStream"
         yum --assumeyes --quiet module install "$appStream"
     done


### PR DESCRIPTION
<!--
First of all, thanks for your pull request!

By sending this pull request you accept the following conditions:

1.  I have read the code of conduct and accept it.
2.  I have read the contributing guidelines and accept them.
3.  I accept that my contribution will be licensed under the AGPLv3.
-->

The installation process for RHEL 8 and CentOS 8 were modified to support PHP7.4 and moreutils

### Added

-   EPEL releases and PowerTools repositories for CentOS 8 added to support moreutils based on official repositories
-   EPEL releases and coderady-builder repositories for RHEL 8 added to support moreutils based on official repositories
-   git now ignores my local ".idea" folder 

### Changed

-   PHP 7.2 -> PHP 7.4 for CentOS 8
-   PHP 7.2 -> PHP 7.4 for RHEL 8

### Removed

-   Plain installation of chronic based on third-party-repository has been removed for RHEL 8 and CentOS 8
